### PR TITLE
Update iOS/iPadOS 18 and 26 build numbers

### DIFF
--- a/compliance/compliance_os_versions.json
+++ b/compliance/compliance_os_versions.json
@@ -68,12 +68,12 @@
             "_comment": "set on 2025-10-15, info iPadOS already on 17.7.10"
         },
         "18": {
-            "Build": "18.7.7",
-            "_comment": "set on 2026-03-27, was 18.7.5"
+            "Build": "18.7.8",
+            "_comment": "set on 2026-04-29, was 18.7.7"
         },
         "26": {
-            "Build": "26.4.1",
-            "_comment": "set on 2026-04-08, was 26.4"
+            "Build": "26.4.2",
+            "_comment": "set on 2026-04-29, was 26.4.1"
         },
         "Future": {
             "Build": "27.0",


### PR DESCRIPTION
## Summary
- iOS/iPadOS 18: 18.7.7 → 18.7.8
- iOS/iPadOS 26: 26.4.1 → 26.4.2

## Test plan
- [ ] Verify compliance policy picks up new minimum build numbers

🤖 Generated with [Claude Code](https://claude.com/claude-code)