### PR TITLE
Update Apple OS build numbers and macOS default_ring target

### DIFF
--- a/compliance/compliance_os_versions.json
+++ b/compliance/compliance_os_versions.json
@@ -1,8 +1,8 @@
 {
     "Windows10": {
         "22H2": {
-            "Build": "10.0.19045.7058",
-            "_comment": "set on 2026-04-16, was 6937, 7058 is 2026-03"
+            "Build": "10.0.19045.7184",
+            "_comment": "set on 2026-05-13, was 7058, 7184 is 2026-04"
         }
     },
     "Windows11": {
@@ -11,28 +11,28 @@
             "_comment": "set on 2025-11-13, 6060 is 2025-10 and End of servicing"
         },
         "23H2": {
-            "Build": "10.0.22631.6783",
-            "_comment": "set on 2026-04-16, was 6649, 6783 is 2026-03"
+            "Build": "10.0.22631.6936",
+            "_comment": "set on 2026-05-13, was 6783, 6936 is 2026-04"
         },
         "24H2": {
-            "Build": "10.0.26100.7979",
-            "_comment": "set on 2026-04-16, was 7840, 7979 is Hotpatch from 2026-03-10"
+            "Build": "10.0.26100.8246",
+            "_comment": "set on 2026-05-13, was 7979, 8246 is hotpatch and baseline from 2026-04"
         },
         "24H2-Beta": {
             "Build": "10.0.26120.6982",
             "_comment": "set on 2025-12-11, 6982 is 2025-10-24, Source is en.wikipedia.org/wiki/Windows_11_version_history"
         },
         "25H2": {
-            "Build": "10.0.26200.7979",
-            "_comment": "set on 2026-04-16, was 7781, 7979 is Hotpatch from 2026-03-10, 7781 is Hotpatch from 2026-02-10"
+            "Build": "10.0.26200.8246",
+            "_comment": "set on 2026-05-13, was 7979, 8246 is hotpatch and baseline from 2026-04"
         },
         "25H2-Beta": {
             "Build": "10.0.26220.7872",
             "_comment": "set on 2026-03-11, was 6982, 6982 is 2025-10-24, 7872 is 2026-02-20"
         },
         "26H1": {
-            "Build": "10.0.28000.1719",
-            "_comment": "set on 2026-04-16, 1719 is release from 2026-03-10"
+            "Build": "10.0.28000.1836",
+            "_comment": "set on 2026-05-13, was 1719, 1836 is 2026-04"
         },
         "Future": {
             "Build": "10.0.26221.0",

--- a/compliance/compliance_os_versions.json
+++ b/compliance/compliance_os_versions.json
@@ -60,8 +60,8 @@
             "_comment": "set on 2026-02-26"
         },
         "16": {
-            "Build": "16.7.15",
-            "_comment": "set on 2026-02-26"
+            "Build": "16.7.16",
+            "_comment": "set on 2026-05-13, was 16.7.15"
         },
         "17": {
             "Build": "17.7.7",
@@ -72,8 +72,8 @@
             "_comment": "set on 2026-04-29, was 18.7.7"
         },
         "26": {
-            "Build": "26.4.2",
-            "_comment": "set on 2026-04-29, was 26.4.1"
+            "Build": "26.5",
+            "_comment": "set on 2026-05-13, was 26.4.2"
         },
         "Future": {
             "Build": "27.0",
@@ -86,12 +86,12 @@
             "_comment": "set a long time ago"
         },
         "Sonoma": {
-            "Build": "14.8.5",
-            "_comment": "set on 2026-04-01, was 14.8.4"
+            "Build": "14.8.7",
+            "_comment": "set on 2026-05-13, was 14.8.5"
         },
         "Sequoia": {
-            "Build": "15.7.5",
-            "_comment": "set on 2026-03-27, was 15.7.4"
+            "Build": "15.7.7",
+            "_comment": "set on 2026-05-13, was 15.7.5"
         },
         "Tahoe": {
             "Build": "26.4.1",

--- a/configuration-policies/macos_update_target_os_versions.json
+++ b/configuration-policies/macos_update_target_os_versions.json
@@ -1,7 +1,7 @@
 {
     "default_ring": {
-        "Build": "26.4.1",
-        "target_time": "2026-04-15T23:00:00"
+        "Build": "26.5",
+        "target_time": "2026-05-21T23:00:00"
     },
     "Sonoma": {
         "Build": "14.8.4",


### PR DESCRIPTION
## Summary
- Update compliance minimums: macOS Sonoma → 14.8.7, Sequoia → 15.7.7; iOS/iPadOS 16 → 16.7.16, 26 → 26.5
- Update macOS `default_ring` target to Build 26.5 with target_time 2026-05-21T23:00:00

## Test plan
- [ ] Verify JSON validity for both files
- [ ] Confirm build numbers and target time match intended values