### PR TITLE
Update minimum required iOS build version for MAM to 17.7.7

### DIFF
--- a/managed-app-policies/app_protection_os_versions.json
+++ b/managed-app-policies/app_protection_os_versions.json
@@ -26,7 +26,7 @@
     "iOSiPadOS": {
         "managed": {
             "minimum_required": {
-                "Build": "15.8.5"
+                "Build": "17.7.7"
             },
             "minimum_warning": {
                 "Build": ""
@@ -37,7 +37,7 @@
         },
         "unmanaged": {
             "minimum_required": {
-                "Build": "15.8.5"
+                "Build": "17.7.7"
             },
             "minimum_warning": {
                 "Build": ""


### PR DESCRIPTION
This pull request updates the minimum required OS build version for iOS/iPadOS devices in the `managed-app-policies/app_protection_os_versions.json` file. Both managed and unmanaged device policies now require a higher minimum OS build.

Minimum OS version updates:

* Increased the `minimum_required` `Build` version for both `managed` and `unmanaged` iOS/iPadOS policies from `15.8.5` to `17.7.7`. [[1]](diffhunk://#diff-922352ff58733ef592404f7930048b823f4611ac61d68d989f7abb41d9126ebfL29-R29) [[2]](diffhunk://#diff-922352ff58733ef592404f7930048b823f4611ac61d68d989f7abb41d9126ebfL40-R40)