### PR TITLE
Update minimum warning and wipe build versions for iOS MAM

### DIFF
--- a/managed-app-policies/app_protection_os_versions.json
+++ b/managed-app-policies/app_protection_os_versions.json
@@ -29,10 +29,10 @@
                 "Build": "17.7.7"
             },
             "minimum_warning": {
-                "Build": ""
+                "Build": "18.7.8"
             },
             "minimum_wipe": {
-                "Build": ""
+                "Build": "17.0"
             }
         },
         "unmanaged": {
@@ -40,10 +40,10 @@
                 "Build": "17.7.7"
             },
             "minimum_warning": {
-                "Build": ""
+                "Build": "18.7.8"
             },
             "minimum_wipe": {
-                "Build": ""
+                "Build": "17.0"
             }
         }
     }


### PR DESCRIPTION
This pull request updates the minimum OS version requirements for app protection policies in the `managed-app-policies/app_protection_os_versions.json` file. The changes set explicit build numbers for the `minimum_warning` and `minimum_wipe` fields for both managed and unmanaged configurations.

Policy version updates:

* Set `minimum_warning` to build `18.7.8` and `minimum_wipe` to build `17.0` for both `managed` and `unmanaged` app protection policies, ensuring clearer enforcement and warning thresholds.