### PR TITLE
Update macOS Tahoe build to 26.5

### DIFF
--- a/compliance/compliance_os_versions.json
+++ b/compliance/compliance_os_versions.json
@@ -94,8 +94,8 @@
             "_comment": "set on 2026-05-13, was 15.7.5"
         },
         "Tahoe": {
-            "Build": "26.4.1",
-            "_comment": "set on 2026-04-16, was 26.4"
+            "Build": "26.5",
+            "_comment": "set on 2026-05-21, was 26.4.1"
         },
         "Future": {
             "Build": "27.0",


### PR DESCRIPTION
## Summary
- Bump `macOS.Tahoe` build in `compliance/compliance_os_versions.json` from `26.4.1` to `26.5`

## Test plan
- [ ] Verify JSON is valid
- [ ] Confirm compliance policy picks up new Tahoe build