### PR TITLE
Update OS versions: iPadOS 15.8.8 and macOS update target 26.5.1

### DIFF
--- a/compliance/compliance_os_versions.json
+++ b/compliance/compliance_os_versions.json
@@ -68,8 +68,8 @@
             "_comment": "set on 2025-10-15, info iPadOS already on 17.7.10"
         },
         "18": {
-            "Build": "18.7.8",
-            "_comment": "set on 2026-04-29, was 18.7.7"
+            "Build": "18.7.9",
+            "_comment": "set on 2026-06-08, was 18.7.8"
         },
         "26": {
             "Build": "26.5",

--- a/compliance/compliance_os_versions.json
+++ b/compliance/compliance_os_versions.json
@@ -64,8 +64,8 @@
             "_comment": "set on 2026-05-13, was 16.7.15"
         },
         "17": {
-            "Build": "17.7.7",
-            "_comment": "set on 2025-10-15, info iPadOS already on 17.7.10"
+            "Build": "17.7.11",
+            "_comment": "set on 2026-06-08, info: all iphones with iOS17 can update to 18"
         },
         "18": {
             "Build": "18.7.9",

--- a/compliance/compliance_os_versions.json
+++ b/compliance/compliance_os_versions.json
@@ -56,8 +56,8 @@
     },
     "iOSiPadOS": {
         "15": {
-            "Build": "15.8.7",
-            "_comment": "set on 2026-02-26"
+            "Build": "15.8.8",
+            "_comment": "set on 2026-06-08, was 15.8.7"
         },
         "16": {
             "Build": "16.7.16",

--- a/configuration-policies/macos_update_target_os_versions.json
+++ b/configuration-policies/macos_update_target_os_versions.json
@@ -1,7 +1,7 @@
 {
     "default_ring": {
-        "Build": "26.5",
-        "target_time": "2026-05-21T23:00:00"
+        "Build": "26.5.1",
+        "target_time": "2026-06-22T23:00:00"
     },
     "Sonoma": {
         "Build": "14.8.4",


### PR DESCRIPTION
## Summary
- **compliance_os_versions.json**:
  - iOSiPadOS `15` build `15.8.7` → `15.8.8`
  - iOSiPadOS `17` build `17.7.7` → `17.7.11`
  - iOSiPadOS `18` build `18.7.8` → `18.7.9`
- **macos_update_target_os_versions.json**: `default_ring` build `26.5` → `26.5.1`, target date `2026-06-22T23:00:00`