### PR TITLE
Update macOS Tahoe to 26.5.1 and remove Windows 11 24H2-Beta

### DIFF
--- a/compliance/compliance_os_versions.json
+++ b/compliance/compliance_os_versions.json
@@ -18,10 +18,6 @@
             "Build": "10.0.26100.8390",
             "_comment": "set on 2026-06-11, was 8246, 8390 is hotpatch from 2026-05"
         },
-        "24H2-Beta": {
-            "Build": "10.0.26120.6982",
-            "_comment": "set on 2025-12-11, 6982 is 2025-10-24"
-        },
         "25H2": {
             "Build": "10.0.26200.8390",
             "_comment": "set on 2026-06-11, was 8246, 8390 is hotpatch from 2026-05"
@@ -94,8 +90,8 @@
             "_comment": "set on 2026-05-13, was 15.7.5"
         },
         "Tahoe": {
-            "Build": "26.5",
-            "_comment": "set on 2026-05-21, was 26.4.1"
+            "Build": "26.5.1",
+            "_comment": "set on 2026-06-25, was 26.5"
         },
         "Future": {
             "Build": "27.0",


### PR DESCRIPTION
## Summary
- Updated macOS Tahoe from `26.5` to `26.5.1`
- Removed Windows 11 `24H2-Beta` entry see BP issue [#222](https://github.com/c4a8/c4a8-issues-workplace/issues/222)

