### PR TITLE
Update macOS Tahoe and iOS/iPadOS 26 versions

### DIFF
--- a/compliance/compliance_os_versions.json
+++ b/compliance/compliance_os_versions.json
@@ -68,8 +68,8 @@
             "_comment": "set on 2026-06-08, was 18.7.8"
         },
         "26": {
-            "Build": "26.5",
-            "_comment": "set on 2026-05-13, was 26.4.2"
+            "Build": "26.5.2",
+            "_comment": "set on 2026-07-08, was 26.5"
         },
         "Future": {
             "Build": "27.0",

--- a/configuration-policies/macos_update_target_os_versions.json
+++ b/configuration-policies/macos_update_target_os_versions.json
@@ -1,7 +1,7 @@
 {
     "default_ring": {
-        "Build": "26.5.1",
-        "target_time": "2026-06-22T23:00:00"
+        "Build": "26.5.2",
+        "target_time": "2026-07-13T23:00:00"
     },
     "Sonoma": {
         "Build": "14.8.4",


### PR DESCRIPTION
## Summary
- Bump macOS Tahoe update target ring to 26.5.2, effective 2026-07-13 23:00
- Bump iOS/iPadOS 26 compliance build to 26.5.2

## Test plan
- N/A (config data update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)