### PR TITLE
Remove macOS Ventura from compliance OS versions

### DIFF
--- a/compliance/compliance_os_versions.json
+++ b/compliance/compliance_os_versions.json
@@ -77,10 +77,6 @@
         }
     },
     "macOS": {
-        "Ventura": {
-            "Build": "13.7.8",
-            "_comment": "set a long time ago"
-        },
         "Sonoma": {
             "Build": "14.8.7",
             "_comment": "set on 2026-05-13, was 14.8.5"


### PR DESCRIPTION
Remove the macOS Ventura entry (Build 13.7.8) from compliance/compliance_os_versions.json — no longer tracked as a supported/compliant OS version
