### PR TITLE
Update macOS/iOS build numbers and Tahoe update target

### DIFF
--- a/compliance/compliance_os_versions.json
+++ b/compliance/compliance_os_versions.json
@@ -68,8 +68,8 @@
             "_comment": "set on 2026-06-08, was 18.7.8"
         },
         "26": {
-            "Build": "26.5.2",
-            "_comment": "set on 2026-07-08, was 26.5"
+            "Build": "26.6",
+            "_comment": "set on 2026-07-29, was 26.5.2"
         },
         "Future": {
             "Build": "27.0",
@@ -78,12 +78,12 @@
     },
     "macOS": {
         "Sonoma": {
-            "Build": "14.8.7",
-            "_comment": "set on 2026-05-13, was 14.8.5"
+            "Build": "14.8.8",
+            "_comment": "set on 2026-07-29, was 14.8.7"
         },
         "Sequoia": {
-            "Build": "15.7.7",
-            "_comment": "set on 2026-05-13, was 15.7.5"
+            "Build": "15.7.8",
+            "_comment": "set on 2026-07-29, was 15.7.7"
         },
         "Tahoe": {
             "Build": "26.5.1",

--- a/configuration-policies/macos_update_target_os_versions.json
+++ b/configuration-policies/macos_update_target_os_versions.json
@@ -1,7 +1,7 @@
 {
     "default_ring": {
-        "Build": "26.5.2",
-        "target_time": "2026-07-13T23:00:00"
+        "Build": "26.6",
+        "target_time": "2026-08-06T23:00:00"
     },
     "Sonoma": {
         "Build": "14.8.4",


### PR DESCRIPTION
- iOSiPadOS 26: 26.5.2 -> 26.6
- macOS Sonoma: 14.8.7 -> 14.8.8
- macOS Sequoia: 15.7.7 -> 15.7.8
- Tahoe default_ring update target: 26.5.2 -> 26.6, target_time 2026-08-06